### PR TITLE
remove skipUp and skipDown, proposal for simplier keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,42 @@ An atom package to easily create more cursors with keystrokes.
 
 ![Multi-cursor demo](https://s3.amazonaws.com/f.cl.ly/items/2X393M1u1G0K0Z061O00/multi-cursor.gif)
 
-Default keymaps are:
+Keymaps in Linux and Windows, override the atom default but with the ability to move the last cursor created:
 
 * **Creating cursors**
-  * <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>cmd</kbd> + <kbd>up</kbd> = Create cursor above
-  * <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>cmd</kbd> + <kbd>down</kbd> = Create cursor under
-  * <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>cmd</kbd> + <kbd>left</kbd> = The next cursor will skip 1 line above
-  * <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>cmd</kbd> + <kbd>right</kbd> = The next cursor will skip 1 line under
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>up</kbd> = Create cursor above
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>down</kbd> = Create cursor under
 * **Moving the last cursor that has been created**
-  * <kbd>alt</kbd> + <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>cmd</kbd> + <kbd>up</kbd> = Move the last-created cursor up
-  * <kbd>alt</kbd> + <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>cmd</kbd> + <kbd>down</kbd> = Move the last-created cursor down
-  * <kbd>alt</kbd> + <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>cmd</kbd> + <kbd>left</kbd> = Move the last-created cursor left
-  * <kbd>alt</kbd> + <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>cmd</kbd> + <kbd>right</kbd> = Move the last-created cursor right
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>up</kbd> = Move the last-created cursor up
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Move the last-created cursor down
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>left</kbd> = Move the last-created cursor left
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>right</kbd> = Move the last-created cursor right
 
-Those may be overriden for your favorite keystroke in your `keymap.cson`
+In OSX commands are:
+* **Creating cursors**
+  * <kbd>ctrl</kbd> + <kbd>up</kbd> = Create cursor above
+  * <kbd>ctrl</kbd> + <kbd>down</kbd> = Create cursor under
+* **Moving the last cursor that has been created**
+  * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>up</kbd> = Move the last-created cursor up
+  * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Move the last-created cursor down
+  * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>left</kbd> = Move the last-created cursor left
+  * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>right</kbd> = Move the last-created cursor right
+
+Those may be overriden for your favorite keystroke in your `keymap.cson` with:
+
+```
+atom-text-editor:not(mini)':
+  # you may have to unset the keybinding if it's alredy in use.
+
+  # Expand current cursor
+  'ctrl-down': 'multi-cursor:expandDown'
+  'ctrl-up':   'multi-cursor:expandUp'
+
+  # Move the last cursor.
+  'ctrl-alt-down':  'multi-cursor:move-last-cursor-down'
+  'ctrl-alt-right': 'multi-cursor:move-last-cursor-right'
+  'ctrl-alt-left':  'multi-cursor:move-last-cursor-left'
+  'ctrl-alt-up':    'multi-cursor:move-last-cursor-up'
+```
 
 Bugs, feature requests and comments are more than welcome in the [issues](https://github.com/joseramonc/multi-cursor/issues) :tada:

--- a/README.md
+++ b/README.md
@@ -4,18 +4,7 @@ An atom package to easily create more cursors with keystrokes.
 
 ![Multi-cursor demo](https://s3.amazonaws.com/f.cl.ly/items/2X393M1u1G0K0Z061O00/multi-cursor.gif)
 
-Keymaps in Linux and Windows, override the atom default but with the ability to move the last cursor created:
-
-* **Creating cursors**
-  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>up</kbd> = Create cursor above
-  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>down</kbd> = Create cursor under
-* **Moving the last cursor that has been created**
-  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>up</kbd> = Move the last-created cursor up
-  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Move the last-created cursor down
-  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>left</kbd> = Move the last-created cursor left
-  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>right</kbd> = Move the last-created cursor right
-
-In OSX commands are:
+## OSX Keymaps:
 * **Creating cursors**
   * <kbd>ctrl</kbd> + <kbd>up</kbd> = Create cursor above
   * <kbd>ctrl</kbd> + <kbd>down</kbd> = Create cursor under
@@ -24,6 +13,29 @@ In OSX commands are:
   * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Move the last-created cursor down
   * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>left</kbd> = Move the last-created cursor left
   * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>right</kbd> = Move the last-created cursor right
+
+## Linux Keymaps:
+
+* **Creating cursors**
+  * <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>up</kbd> = Create cursor above
+  * <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>down</kbd> = Create cursor under
+* **Moving the last cursor that has been created**
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>up</kbd> = Move the last-created cursor up
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Move the last-created cursor down
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>left</kbd> = Move the last-created cursor left
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>right</kbd> = Move the last-created cursor right
+
+
+## Windows Keymaps:
+
+* **Creating cursors**
+  * <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>up</kbd> = Create cursor above
+  * <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>down</kbd> = Create cursor under
+* **Moving the last cursor that has been created**
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>up</kbd> = Move the last-created cursor up
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Move the last-created cursor down
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>left</kbd> = Move the last-created cursor left
+  * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>right</kbd> = Move the last-created cursor right
 
 Those may be overriden for your favorite keystroke in your `keymap.cson` with:
 

--- a/keymaps/multi-cursor.cson
+++ b/keymaps/multi-cursor.cson
@@ -7,12 +7,14 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'atom-text-editor':
-  'alt-shift-cmd-down': 'multi-cursor:expandDown'
-  'alt-shift-cmd-right': 'multi-cursor:skipDown'
-  'alt-shift-cmd-left': 'multi-cursor:skipUp'
-  'alt-shift-cmd-up': 'multi-cursor:expandUp'
-  'alt-ctrl-shift-cmd-down': 'multi-cursor:move-last-cursor-down'
-  'alt-ctrl-shift-cmd-right': 'multi-cursor:move-last-cursor-right'
-  'alt-ctrl-shift-cmd-left': 'multi-cursor:move-last-cursor-left'
-  'alt-ctrl-shift-cmd-up': 'multi-cursor:move-last-cursor-up'
+'atom-text-editor:not(mini)':
+
+  # Expand current cursor
+  'ctrl-down': 'multi-cursor:expandDown'
+  'ctrl-up':   'multi-cursor:expandUp'
+
+  # Move the last cursor.
+  'ctrl-alt-down':  'multi-cursor:move-last-cursor-down'
+  'ctrl-alt-right': 'multi-cursor:move-last-cursor-right'
+  'ctrl-alt-left':  'multi-cursor:move-last-cursor-left'
+  'ctrl-alt-up':    'multi-cursor:move-last-cursor-up'

--- a/keymaps/multi-cursor.cson
+++ b/keymaps/multi-cursor.cson
@@ -7,7 +7,10 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'atom-text-editor:not(mini)':
+
+# OSX keymaps are different, because ctrl-shift is an OS shortcut for
+# mission control and application windows by default.
+'.platform-darwin atom-text-editor:not(mini)':
 
   # Expand current cursor
   'ctrl-down': 'multi-cursor:expandDown'
@@ -18,3 +21,18 @@
   'ctrl-alt-right': 'multi-cursor:move-last-cursor-right'
   'ctrl-alt-left':  'multi-cursor:move-last-cursor-left'
   'ctrl-alt-up':    'multi-cursor:move-last-cursor-up'
+
+
+'.platform-win32 atom-text-editor:not(mini),
+  .platform-linux atom-text-editor:not(mini)':
+  # 'atom-text-editor:not(mini)':
+
+  # Expand current cursor
+  'ctrl-shift-down': 'multi-cursor:expandDown'
+  'ctrl-shift-up':   'multi-cursor:expandUp'
+
+  # Move the last cursor.
+  'ctrl-shift-alt-down':  'multi-cursor:move-last-cursor-down'
+  'ctrl-shift-alt-right': 'multi-cursor:move-last-cursor-right'
+  'ctrl-shift-alt-left':  'multi-cursor:move-last-cursor-left'
+  'ctrl-shift-alt-up':    'multi-cursor:move-last-cursor-up'

--- a/keymaps/multi-cursor.cson
+++ b/keymaps/multi-cursor.cson
@@ -8,13 +8,14 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 
-# OSX keymaps are different, because ctrl-shift is an OS shortcut for
+# OSX keymaps are different of atom's default
+# because ctrl-shift up and down are OS shortcuts for
 # mission control and application windows by default.
 '.platform-darwin atom-text-editor:not(mini)':
 
   # Expand current cursor
-  'ctrl-down': 'multi-cursor:expandDown'
-  'ctrl-up':   'multi-cursor:expandUp'
+  'alt-down': 'multi-cursor:expandDown'
+  'alt-up':   'multi-cursor:expandUp'
 
   # Move the last cursor.
   'ctrl-alt-down':  'multi-cursor:move-last-cursor-down'
@@ -23,16 +24,33 @@
   'ctrl-alt-up':    'multi-cursor:move-last-cursor-up'
 
 
-'.platform-win32 atom-text-editor:not(mini),
-  .platform-linux atom-text-editor:not(mini)':
-  # 'atom-text-editor:not(mini)':
+
+# Linux keybindings
+'.platform-linux atom-text-editor:not(mini)':
 
   # Expand current cursor
-  'ctrl-shift-down': 'multi-cursor:expandDown'
-  'ctrl-shift-up':   'multi-cursor:expandUp'
+  'alt-shift-down': 'multi-cursor:expandDown'
+  'alt-shift-up':   'multi-cursor:expandUp'
 
   # Move the last cursor.
   'ctrl-shift-alt-down':  'multi-cursor:move-last-cursor-down'
   'ctrl-shift-alt-right': 'multi-cursor:move-last-cursor-right'
   'ctrl-shift-alt-left':  'multi-cursor:move-last-cursor-left'
+
+
+
+# Windows keybindings
+'.platform-win32 atom-text-editor:not(mini)':
+
+  # Expand current cursor
+  'ctrl-alt-down': 'multi-cursor:expandDown'
+  'ctrl-alt-up':   'multi-cursor:expandUp'
+
+  # Move the last cursor.
+  'ctrl-shift-alt-down':  'multi-cursor:move-last-cursor-down'
+  'ctrl-shift-alt-right': 'multi-cursor:move-last-cursor-right'
+  'ctrl-shift-alt-left':  'multi-cursor:move-last-cursor-left'
+  'ctrl-shift-alt-up':    'multi-cursor:move-last-cursor-up'
+
+
   'ctrl-shift-alt-up':    'multi-cursor:move-last-cursor-up'

--- a/lib/multi-cursor.coffee
+++ b/lib/multi-cursor.coffee
@@ -15,8 +15,6 @@ module.exports = MultiCursor =
 
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expandDown': => @expandDown()
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expandUp': => @expandUp()
-    @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:skipDown': => @skipDown()
-    @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:skipUp': => @skipUp()
 
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:move-last-cursor-up': => @moveLastCursorUp()
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:move-last-cursor-down': => @moveLastCursorDown()
@@ -31,12 +29,6 @@ module.exports = MultiCursor =
 
   serialize: ->
     @currentPosition = null
-
-  skipDown: ->
-    @skipCount++
-
-  skipUp: ->
-    @skipCount--
 
   expandDown: ->
     @expandInDirection(1)


### PR DESCRIPTION
@jacekkopecky @wolftune This overrides the default keybindings provided by atom for expanding cursor, this may cause problems with OSX at least, but people can always override their keybindings to old ones, or remove OS global shortcuts, with this new keybindings #11 might get fixed too.

Also removes skipUp and skipDown since `move-last-cursor-*` actions are better for moving cursor around.

Do you have any better options or conflicts with this keybindings? 
