### PR TITLE
fix readme text to reflect actual keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ An atom package to easily create more cursors with keystrokes.
 
 ## OSX Keymaps:
 * **Creating cursors**
-  * <kbd>ctrl</kbd> + <kbd>up</kbd> = Create cursor above
-  * <kbd>ctrl</kbd> + <kbd>down</kbd> = Create cursor under
+  * <kbd>alt</kbd> + <kbd>up</kbd> = Create cursor above
+  * <kbd>alt</kbd> + <kbd>down</kbd> = Create cursor under
 * **Moving the last cursor that has been created**
   * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>up</kbd> = Move the last-created cursor up
   * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Move the last-created cursor down


### PR DESCRIPTION
The default behavior of ctrl-up/down on OSX is to expose all windows on the desktop (I doubt you want to override that) but fortunately it's just a typo in the readme I think? alt-up/down seems to be the actual key map that is bound (see https://github.com/joseramonc/multi-cursor/blob/master/keymaps/multi-cursor.cson#L18)
