### PR TITLE
Update Readme to edit keymap.cson directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ An atom package to easily create more cursors with keystrokes.
 Those may be overriden for your favorite keystroke in your `keymap.cson` with:
 
 ```
-atom-text-editor:not(mini)':
+'atom-workspace atom-text-editor:not([mini])':
   # you may have to unset the keybinding if it's alredy in use.
 
   # Expand current cursor

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Those may be overriden for your favorite keystroke in your `keymap.cson` with:
 
 ```
 'atom-workspace atom-text-editor:not([mini])':
-  # you may have to unset the keybinding if it's alredy in use.
+  # you may have to unset the keybinding if it's already in use.
 
   # Expand current cursor
   'ctrl-down': 'multi-cursor:expandDown'


### PR DESCRIPTION
The original directions are missing an apostrophe and brackets, so it didn't function for me until I updated it to this.

The correct syntax for the keybinding you want to change can be obtained by going to "Settings" -> "Keybindings".  
- Search for the keybinding that you're having issues with (like ctrl-down), and click the clipboard icon next to the keystroke.
- Paste that syntax into the keymap.cson file and edit as necessary.

![image](https://cloud.githubusercontent.com/assets/876146/12053186/2ed67068-aedc-11e5-8d08-5e1f26f9f51e.png)
