### PR TITLE
Change hotkeys on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ An atom package to easily create more cursors with keystrokes.
 ## Windows Keymaps:
 
 * **Creating cursors**
-  * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>up</kbd> = Create cursor above
-  * <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Create cursor under
+  * <kbd>alt</kbd> + <kbd>up</kbd> = Create cursor above
+  * <kbd>alt</kbd> + <kbd>down</kbd> = Create cursor under
 * **Moving the last cursor that has been created**
   * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>up</kbd> = Move the last-created cursor up
   * <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>down</kbd> = Move the last-created cursor down

--- a/keymaps/multi-cursor.cson
+++ b/keymaps/multi-cursor.cson
@@ -45,8 +45,8 @@
 '.platform-win32 atom-text-editor:not(mini)':
 
   # Expand current cursor
-  'ctrl-alt-down': 'multi-cursor:expandDown'
-  'ctrl-alt-up':   'multi-cursor:expandUp'
+  'alt-down': 'multi-cursor:expandDown'
+  'alt-up':   'multi-cursor:expandUp'
 
   # Move the last cursor.
   'ctrl-shift-alt-down':  'multi-cursor:move-last-cursor-down'


### PR DESCRIPTION
Ctrl + alt + arrow keys rotates the screen for many graphic drivers on windows.
However alt + up/down is not used.
