### PR TITLE
fix conflicting keys for Linux systems

### DIFF
--- a/keymaps/multi-cursor.cson
+++ b/keymaps/multi-cursor.cson
@@ -30,8 +30,8 @@
 '.platform-linux atom-text-editor:not(mini)':
 
   # Expand current cursor
-  'alt-shift-down': 'multi-cursor:expandDown'
-  'alt-shift-up':   'multi-cursor:expandUp'
+  'ctrl-shift-down': 'multi-cursor:expandDown'
+  'ctrl-shift-up':   'multi-cursor:expandUp'
 
   # Move the last cursor.
   'ctrl-shift-alt-down':  'multi-cursor:move-last-cursor-down'


### PR DESCRIPTION
<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>Up</kbd>/<kbd>Down</kbd> was conflicting on Linux machines with a native keyboard shortcut.

As a result, replace <kbd>Alt</kbd> key with <kbd>Ctrl</kbd> to avoid any more conflicts.

Resolves: #20
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>