### PR TITLE
Add ExpandAllUp and ExpandAllDown feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Those may be overriden for your favorite keystroke in your `keymap.cson` with:
 'atom-workspace atom-text-editor:not([mini])':
   # you may have to unset the keybinding if it's already in use.
 
-  # Expand current cursor
+  # Expand last cursor
   'ctrl-down': 'multi-cursor:expandDown'
   'ctrl-up':   'multi-cursor:expandUp'
+  'ctrl-cmd-down': 'multi-cursor:expand-all-down'
+  'ctrl-cmd-up':   'multi-cursor:expand-all-up'
 
   # Move the last cursor.
   'ctrl-alt-down':  'multi-cursor:move-last-cursor-down'

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ Those may be overriden for your favorite keystroke in your `keymap.cson` with:
   # you may have to unset the keybinding if it's already in use.
 
   # Expand last cursor
-  'ctrl-down': 'multi-cursor:expandDown'
-  'ctrl-up':   'multi-cursor:expandUp'
+  'ctrl-down': 'multi-cursor:expand-down'
+  'ctrl-up':   'multi-cursor:expand-up'
+
+  # Expand all Cursors
   'ctrl-cmd-down': 'multi-cursor:expand-all-down'
   'ctrl-cmd-up':   'multi-cursor:expand-all-up'
 

--- a/keymaps/multi-cursor.cson
+++ b/keymaps/multi-cursor.cson
@@ -2,9 +2,6 @@
 # matched against the focused element, the keystroke and the command to
 # execute.
 #
-# Below is a basic keybinding which registers on all platforms by applying to
-# the root workspace element.
-
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 
@@ -15,8 +12,8 @@
 '.platform-darwin atom-text-editor:not(mini)':
 
   # Expand current cursor
-  'alt-down': 'multi-cursor:expandDown'
-  'alt-up':   'multi-cursor:expandUp'
+  'alt-down': 'multi-cursor:expand-down'
+  'alt-up':   'multi-cursor:expand-up'
 
   # Move the last cursor.
   'ctrl-alt-down':  'multi-cursor:move-last-cursor-down'
@@ -30,8 +27,8 @@
 '.platform-linux atom-text-editor:not(mini)':
 
   # Expand current cursor
-  'ctrl-shift-down': 'multi-cursor:expandDown'
-  'ctrl-shift-up':   'multi-cursor:expandUp'
+  'ctrl-shift-down': 'multi-cursor:expand-down'
+  'ctrl-shift-up':   'multi-cursor:expand-up'
 
   # Move the last cursor.
   'ctrl-shift-alt-down':  'multi-cursor:move-last-cursor-down'
@@ -45,8 +42,8 @@
 '.platform-win32 atom-text-editor:not(mini)':
 
   # Expand current cursor
-  'alt-down': 'multi-cursor:expandDown'
-  'alt-up':   'multi-cursor:expandUp'
+  'alt-down': 'multi-cursor:expand-down'
+  'alt-up':   'multi-cursor:expand-up'
 
   # Move the last cursor.
   'ctrl-shift-alt-down':  'multi-cursor:move-last-cursor-down'

--- a/lib/multi-cursor.coffee
+++ b/lib/multi-cursor.coffee
@@ -13,8 +13,8 @@ module.exports = MultiCursor =
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     @subscriptions = new CompositeDisposable
 
-    @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expandDown': => @expandDown()
-    @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expandUp': => @expandUp()
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expand-down': => @expandDown()
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expand-up': => @expandUp()
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expand-all-up': => @expandAllUp()
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expand-all-down': => @expandAllDown()
 

--- a/lib/multi-cursor.coffee
+++ b/lib/multi-cursor.coffee
@@ -15,6 +15,8 @@ module.exports = MultiCursor =
 
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expandDown': => @expandDown()
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expandUp': => @expandUp()
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expand-all-up': => @expandAllUp()
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:expand-all-down': => @expandAllDown()
 
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:move-last-cursor-up': => @moveLastCursorUp()
     @subscriptions.add atom.commands.add 'atom-text-editor', 'multi-cursor:move-last-cursor-down': => @moveLastCursorDown()
@@ -35,6 +37,24 @@ module.exports = MultiCursor =
 
   expandUp: ->
     @expandInDirection(-1)
+
+  expandAllUp: ->
+    return unless editor = atom.workspace.getActiveTextEditor()
+    return unless lastCursor = editor.getLastCursor()
+    cursors = editor.getCursors()
+    coords = lastCursor.getBufferPosition()
+
+    for line in [1..coords.row]
+      @expandUp()
+
+  expandAllDown: ->
+    return unless editor = atom.workspace.getActiveTextEditor()
+    return unless lastCursor = editor.getLastCursor()
+    cursors = editor.getCursors()
+    coords = lastCursor.getBufferPosition()
+
+    for line in [coords.row..editor.getLineCount()]
+      @expandDown()
 
   expandInDirection: (dir) ->
     return unless editor = atom.workspace.getActiveTextEditor()

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "description": "Atom package to expand your current cursor.",
   "activationCommands": {
     "atom-workspace": [
-      "multi-cursor:expandDown",
-      "multi-cursor:expandUp",
-      "multi-cursor:expandAllUp",
-      "multi-cursor:expandAllDown",
-      "multi-cursor:skipDown",
-      "multi-cursor:skipUp",
+      "multi-cursor:expand-down",
+      "multi-cursor:expand-up",
+
+      "multi-cursor:expand-all-up",
+      "multi-cursor:expand-all-down",
+
       "multi-cursor:move-last-cursor-up",
       "multi-cursor:move-last-cursor-down",
       "multi-cursor:move-last-cursor-left",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "atom-workspace": [
       "multi-cursor:expandDown",
       "multi-cursor:expandUp",
+      "multi-cursor:expandAllUp",
+      "multi-cursor:expandAllDown",
       "multi-cursor:skipDown",
       "multi-cursor:skipUp",
       "multi-cursor:move-last-cursor-up",

--- a/spec/multi-cursor-spec.coffee
+++ b/spec/multi-cursor-spec.coffee
@@ -15,7 +15,7 @@ describe "MultiCursor", ->
     view.setCursorBufferPosition([0,0])
     activationPromise = atom.packages.activatePackage('multi-cursor')
 
-  describe "when the multi-cursor:expandDown event is triggered", ->
+  describe "when the multi-cursor:expand-down event is triggered", ->
     it "When there's 1 cursor and down command is activated", ->
       jasmine.attachToDOM(workspaceElement)
 
@@ -24,5 +24,5 @@ describe "MultiCursor", ->
 
       runs ->
         expect(view.getCursors().length).toBe(1)
-        atom.commands.dispatch workspaceElement, 'multi-cursor:expandDown'
+        atom.commands.dispatch workspaceElement, 'multi-cursor:expand-down'
         expect(view.getCursors().length).toBe(2)


### PR DESCRIPTION
Implementation of feature requested in #44 and #46 (sorry for taking so long) this feature doesn't provide an out of the box keybinding, as it can potentially freeze atom if used on very large files.

However, I'm adding the instructions to set a keybinding to the readme so it's easier to do so if desired.

```
'atom-workspace atom-text-editor:not([mini])':

  # Expand all Cursors
  'ctrl-cmd-down': 'multi-cursor:expand-all-down'
  'ctrl-cmd-up':   'multi-cursor:expand-all-up'
```

This PR also fixes a naming convention issue with the commands (and removed 2 old commands), so existing keybindings (overrided only) for `expandUp` and `expandDown` will no longer work, they will need to be updated from:
```
  'ctrl-down': 'multi-cursor:expandDown'
  'ctrl-up':   'multi-cursor:expandUp'
```

to
```
  'ctrl-down': 'multi-cursor:expand-down'
  'ctrl-up':   'multi-cursor:expand-up'
```